### PR TITLE
Reentrancy checks

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -29,7 +29,7 @@
       }
     ],
     "reason-string": ["warn", { "maxLength": 64 }],
-    "reentrancy": "warn",
+    "reentrancy": "error",
     "state-visibility": "error",
     "use-forbidden-name": "warn",
     "var-name-mixedcase": "warn",

--- a/.solhint.json
+++ b/.solhint.json
@@ -29,7 +29,7 @@
       }
     ],
     "reason-string": ["warn", { "maxLength": 64 }],
-    "reentrancy": "error",
+    "reentrancy": "off",
     "state-visibility": "error",
     "use-forbidden-name": "warn",
     "var-name-mixedcase": "warn",

--- a/.solhint.json
+++ b/.solhint.json
@@ -29,7 +29,7 @@
       }
     ],
     "reason-string": ["warn", { "maxLength": 64 }],
-    "reentrancy": "off",
+    "reentrancy": "warn",
     "state-visibility": "error",
     "use-forbidden-name": "warn",
     "var-name-mixedcase": "warn",

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -77,6 +77,10 @@ contract Vault is IVault, ERC4626, ERC20Permit {
         return (currentProfits, currentLosses, feeUnlockTime, latestRepay);
     }
 
+    function getLoansAndLiquidity() external view override returns (uint256, uint256) {
+        return (netLoans, freeLiquidity());
+    }
+
     // Total assets are used to calculate shares to mint and redeem
     // They represent the deposited amount, the loans and the unlocked fees
     // As per ERC4626 standard this must never throw

--- a/src/interfaces/IVault.sol
+++ b/src/interfaces/IVault.sol
@@ -30,6 +30,8 @@ interface IVault is IERC4626 {
 
     function getFeeStatus() external view returns (uint256, uint256, uint256, uint256);
 
+    function getLoansAndLiquidity() external view returns (uint256, uint256);
+
     function toggleLock() external;
 
     function isLocked() external view returns (bool);

--- a/src/services/DebitService.sol
+++ b/src/services/DebitService.sol
@@ -69,6 +69,8 @@ abstract contract DebitService is Service, BaseRiskModel {
             );
             // No need to launch borrow if amount is zero
             uint256 freeLiquidity;
+            // this call does not constitute reentrancy, since transferring additional margin
+            // has the same effect as opening a single position with the sum of the two margins
             (freeLiquidity, ) = manager.borrow(
                 agreement.loans[index].token,
                 agreement.loans[index].amount,
@@ -100,11 +102,11 @@ abstract contract DebitService is Service, BaseRiskModel {
             // first repay the liquidator
             // the liquidation reward can never be higher than the margin
             // if the liquidable position is closed by its owner, it is *not* considered a liquidation event
+            uint256 liquidatorReward;
             if (agreementOwner != msg.sender) {
                 // This can either due to score > 0 or deadline exceeded
                 // In the latter case, the fee is linear with time until reacing 5% in one month (31 days)
                 // If a position is both liquidable and expired, liquidation has the priority
-                uint256 liquidatorReward;
                 if (score > 0) liquidatorReward = (agreement.loans[index].margin * score) / RESOLUTION;
                 else {
                     // in this case agreement.createdAt + deadline <= block.timestamp
@@ -116,7 +118,6 @@ abstract contract DebitService is Service, BaseRiskModel {
                 // We cap further the liquidation reward with the obtained amount (no cross-position rewarding)
                 // This also prevents the following transfer to revert
                 liquidatorReward = liquidatorReward < obtained[index] ? liquidatorReward : obtained[index];
-                IERC20(agreement.loans[index].token).safeTransfer(msg.sender, liquidatorReward);
                 obtained[index] -= liquidatorReward;
 
                 emit LiquidationTriggered(tokenID, agreement.loans[index].token, msg.sender, liquidatorReward);
@@ -139,6 +140,10 @@ abstract contract DebitService is Service, BaseRiskModel {
 
             // repay the owner
             IERC20(agreement.loans[index].token).safeTransfer(agreementOwner, obtained[index] - repaidAmount);
+
+            // in case liquidatorReward > 0, a liquidation has occurred and msg.sender is the liquidator
+            // at this point to prevent liquidator side reentrancy attacks damaging the users
+            if (liquidatorReward > 0) IERC20(agreement.loans[index].token).safeTransfer(msg.sender, liquidatorReward);
         }
 
         return obtained;

--- a/src/services/credit/SeniorCallOption.sol
+++ b/src/services/credit/SeniorCallOption.sol
@@ -40,6 +40,8 @@ contract SeniorCallOption is CreditService {
     uint64[] internal _rewards;
     address internal immutable _vaultAddress;
 
+    bool internal _reentrancyGuard;
+
     error ZeroAmount();
     error LockPeriodStillActive();
     error MaxLockExceeded();
@@ -97,6 +99,15 @@ contract SeniorCallOption is CreditService {
         _rewards[9] = 1781797436280678609;
         _rewards[10] = 1887748625363386993;
         _rewards[11] = 2000000000000000000;
+
+        _reentrancyGuard = false;
+    }
+
+    modifier nonReentrant() {
+        require(!_reentrancyGuard, "Nice try");
+        _reentrancyGuard = true;
+        _;
+        _reentrancyGuard = false;
     }
 
     function _open(Agreement memory agreement, bytes memory data) internal override {
@@ -152,7 +163,14 @@ contract SeniorCallOption is CreditService {
         IVault(_vaultAddress).deposit(agreement.loans[0].amount, address(this));
     }
 
-    function _close(uint256 tokenID, IService.Agreement memory agreement, bytes memory data) internal virtual override {
+    // the following must have a reentrancy guard since we do not have token minting
+    // therefore we do not have any state variable which prevents an attacker from continuously losing
+    // and continuously being refunded by the vault until the min(vaultLiquidity, thisLiquidity) is drained
+    function _close(
+        uint256 tokenID,
+        IService.Agreement memory agreement,
+        bytes memory data
+    ) internal virtual override nonReentrant {
         // The position can be closed only after the locking period
         if (block.timestamp < agreement.createdAt + deadline - tenorDuration) revert LockPeriodStillActive();
         // The portion of the loan amount we want to call
@@ -194,8 +212,6 @@ contract SeniorCallOption is CreditService {
         // We will always have ithil.balanceOf(address(this)) >= toCall, so the following succeeds
         ithil.safeTransfer(ownerAddress, toCall);
         // repay the user's losses
-        // if an attacker were able to manipulate the vault status in some way, it could make the redeem fail
-        // therefore this call must be after redeem in order to prevent reentrancy
         if (toBorrow > 0 && freeLiquidity > 0) manager.borrow(agreement.loans[0].token, toBorrow, 0, ownerAddress);
     }
 

--- a/src/services/credit/SeniorFixedYieldService.sol
+++ b/src/services/credit/SeniorFixedYieldService.sol
@@ -40,6 +40,7 @@ contract SeniorFixedYieldService is CreditService {
             IERC20(agreement.loans[0].token).approve(vaultAddress, type(uint256).max);
         // Deposit tokens to the relevant vault and register obtained amount
         uint256 shares = IVault(vaultAddress).deposit(agreement.loans[0].amount, address(this));
+        // This check is here to protect the msg.sender from slippage, therefore reentrancy is not an issue
         if (shares < agreement.collaterals[0].amount) revert SlippageExceeded();
         agreement.collaterals[0].amount = shares;
     }

--- a/src/services/debit/AaveService.sol
+++ b/src/services/debit/AaveService.sol
@@ -44,6 +44,7 @@ contract AaveService is Whitelisted, AuctionRateModel, DebitService {
         aave.supply(agreement.loans[0].token, agreement.loans[0].amount + agreement.loans[0].margin, address(this), 0);
 
         uint256 computedCollateral = aToken.balanceOf(address(this)) - initialBalance;
+        // This check is here to protect the msg.sender from slippage, therefore reentrancy is not an issue
         if (computedCollateral < agreement.collaterals[0].amount) revert InsufficientAmountOut();
         agreement.collaterals[0].amount = computedCollateral;
         // Due to the above check, totalAllowance is positive if there is at least one open agreement
@@ -62,6 +63,7 @@ contract AaveService is Whitelisted, AuctionRateModel, DebitService {
             ? totalAllowance[agreement.collaterals[0].token] - agreement.collaterals[0].amount
             : 0;
         uint256 amountIn = aave.withdraw(agreement.loans[0].token, toRedeem, address(this));
+        // This check is here to protect the msg.sender from slippage, therefore reentrancy is not an issue
         if (amountIn < minimumAmountOut) revert InsufficientAmountOut();
     }
 

--- a/src/services/debit/GmxService.sol
+++ b/src/services/debit/GmxService.sol
@@ -68,6 +68,7 @@ contract GmxService is Whitelisted, AuctionRateModel, DebitService {
         );
 
         totalCollateral += agreement.collaterals[0].amount;
+        // This check is here to protect the msg.sender from slippage, therefore reentrancy is not an issue
         if (totalCollateral == 0) revert ZeroGlpSupply();
         // we assign a virtual deposit of v * A / S, __afterwards__ we update the total deposits
         virtualDeposit[id] =


### PR DESCRIPTION
In manager, one could make a loop of vault.borrow and eventually circumvent the cap enforcement. Fixed.
In debit services, the liquidator could make the liquidation call fail after getting the reward and until the entire user's margin is drained. Fixed.
In call option at the redeem, one could manipulate the vault status so to always have losses and by a loop of applications of seniority, which would repay him of the losses, he could drain the entire vault (it was the most serious vulnerability). Fixed by adding a reentrancy guard.
In base service, one can reenter and switch msg.sender who opens the position to a non-ERC721 receiver, thus opening positions which cannot be closed. Fixed by adding a reentrancy guard.